### PR TITLE
Need double quotes around vars when they include spaces

### DIFF
--- a/Installation/cleanup_script.sh
+++ b/Installation/cleanup_script.sh
@@ -86,7 +86,7 @@ function removeMySQL() {
 
 function removeRepos() {
   if [ -d /etc/yum.repos.d ]; then
-    cd /etc/yum.repos.d && egrep $REPO_FILTER *.repo | awk -F: '{ print $1; }' | sort -u | xargs -n 1 rm -f
+    cd /etc/yum.repos.d && egrep "$REPO_FILTER" *.repo | awk -F: '{ print $1; }' | sort -u | xargs -n 1 rm -f
   fi
 }
 


### PR DESCRIPTION
The variable $REPO_FILTER includes spaces so it needs to be properly quoted as an argument to egrep.